### PR TITLE
fix: fix flaky test in CollectionTests

### DIFF
--- a/src/test/java/com/cedarsoftware/io/CollectionTests.java
+++ b/src/test/java/com/cedarsoftware/io/CollectionTests.java
@@ -24,6 +24,11 @@ import java.util.TreeSet;
 import com.cedarsoftware.util.DeepEquals;
 import com.cedarsoftware.util.FastByteArrayOutputStream;
 import com.cedarsoftware.util.SealableList;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.jupiter.api.Test;
 
 import static com.cedarsoftware.util.CollectionUtilities.listOf;
@@ -383,7 +388,7 @@ class CollectionTests {
     }
 
     @Test
-    void testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded() {
+    void testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded() throws JsonMappingException, JsonProcessingException {
 
         WriteOptions writeOptions = new WriteOptionsBuilder().writeEnumAsJsonObject(false).build();
 
@@ -392,7 +397,10 @@ class CollectionTests {
         String json = TestUtil.toJson(arrayList, writeOptions);
         TestUtil.printLine(json);
         String className = CollectionTests.class.getName();
-        assertEquals("{\"@type\":\"ArrayList\",\"@items\":[{\"@type\":\"" + className + "$TestEnum4\",\"age\":21,\"foo\":\"bar\",\"name\":\"B\"}]}", json);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode outputNode = mapper.readTree("{\"@type\":\"ArrayList\",\"@items\":[{\"@type\":\"" + className + "$TestEnum4\",\"age\":21,\"foo\":\"bar\",\"name\":\"B\"}]}");
+        JsonNode expectedNode = mapper.readTree(json);
+        assertEquals(outputNode, expectedNode);
     }
 
     @Test


### PR DESCRIPTION
## Problem
The test `testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded` originally tests if the result json of the enum follows the order `... age:21, foo: bar, name: B ...`. However the output json might have different order for the key-value pairs. For example, `foo: bar, age: 21, name: B`. This would result in a failed test.

This problem was found using [NonDex](https://www.cs.cornell.edu/~legunsen/pubs/GyoriETAL16NonDexToolDemo.pdf) by running the following:
```
mvn -pl . \
edu.illinois:nondex-maven-plugin:2.1.7:nondex \
Dtest=com.cedarsoftware.io.CollectionTests#testEnumsInsideOfACollection_whenWritingAsObject_withPrivateMembersIncluded
```
## Fix
To effectively compare the output json with the expected json, I used the `ObjectMapper` from `Jackson` to read both jsons as `JsonNode` and assert that these nodes are equal.